### PR TITLE
Add Multiple Datapoint per Message Support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <name>opentsdb-rpc-kafka</name>
     <groupId>net.opentsdb</groupId>
     <artifactId>opentsdb-rpc-kafka</artifactId>
-    <version>2.3.0-SNAPSHOT</version>
+    <version>2.3.1-SNAPSHOT</version>
     <description>A consumer and publisher for OpenTSDB Kafka messages</description>
 
     <packaging>jar</packaging>

--- a/src/main/java/net/opentsdb/tsd/KafkaRpcPlugin.java
+++ b/src/main/java/net/opentsdb/tsd/KafkaRpcPlugin.java
@@ -62,6 +62,7 @@ public class KafkaRpcPlugin extends RpcPlugin implements TimerTask {
   
   private final Map<String, AtomicLong> totals_counters;
   private final AtomicLong messages_received = new AtomicLong();
+  private final AtomicLong datapoints_received = new AtomicLong();
   private final AtomicLong deserialization_errors = new AtomicLong();
   private final AtomicLong restarts = new AtomicLong();
   private final AtomicLong rebalance_failures = new AtomicLong();
@@ -205,6 +206,7 @@ public class KafkaRpcPlugin extends RpcPlugin implements TimerTask {
           new HashMap<String, Long>(CounterType.values().length);  
       
       long tempMessageReceived = 0;
+      long tempDatapointsReceived = 0;
       long tempDeserializationError = 0;
       long tempRestarts = 0;
       long tempRebalanceFailures = 0;
@@ -214,6 +216,7 @@ public class KafkaRpcPlugin extends RpcPlugin implements TimerTask {
       for (final KafkaRpcPluginGroup group : consumer_groups) {
         //group.getNamespaceCounters(tempNamespaceCounters);
         tempMessageReceived += group.getMessagesReceived();
+        tempDatapointsReceived += group.getDatapointsReceived();
         tempDeserializationError += group.getDeserializationErrors();
         tempRestarts += group.getRestarts();
         tempRebalanceFailures += group.getRebalanceFailures();
@@ -222,6 +225,7 @@ public class KafkaRpcPlugin extends RpcPlugin implements TimerTask {
       }
       
       messages_received.set(tempMessageReceived);
+      datapoints_received.set(tempDatapointsReceived);
       deserialization_errors.set(tempDeserializationError);
       restarts.set(tempRestarts);
       rebalance_failures.set(tempRebalanceFailures);

--- a/src/main/java/net/opentsdb/tsd/KafkaRpcPluginGroup.java
+++ b/src/main/java/net/opentsdb/tsd/KafkaRpcPluginGroup.java
@@ -207,6 +207,15 @@ public class KafkaRpcPluginGroup implements TimerTask {
     }
     return temp;
   }
+
+  /** @return the number of datapoints received across all threads */
+  public long getDatapointsReceived() {
+    long temp = 0;
+    for (final KafkaRpcPluginThread consumer : kafka_consumers) {
+      temp += consumer.getDatapointsReceived();
+    }
+    return temp;
+  }
   
   /** @return the number of seconds spent waiting on the rate limiter */
   public double getCumulativeRateDelay() {
@@ -272,6 +281,7 @@ public class KafkaRpcPluginGroup implements TimerTask {
     for (final KafkaRpcPluginThread consumer : kafka_consumers) {
       final Map<String, Double> thread = new HashMap<String, Double>();
       thread.put("messagesReceived", (double)consumer.getMessagesReceived());
+      thread.put("datapointsReceived", (double)consumer.getDatapointsReceived());
       thread.put("cumulativeRateDelay", consumer.getCumulativeRateDelay());
       thread.put("kafkaWaitTime", consumer.getKafkaWaitTime());
       map.put(consumer.threadID(), thread);

--- a/src/main/java/net/opentsdb/tsd/KafkaRpcPluginThread.java
+++ b/src/main/java/net/opentsdb/tsd/KafkaRpcPluginThread.java
@@ -12,12 +12,15 @@
 // see <http://www.gnu.org/licenses/>.
 package net.opentsdb.tsd;
 
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.util.concurrent.AtomicDouble;
 import com.google.common.util.concurrent.RateLimiter;
 
 import joptsimple.internal.Strings;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.ConcurrentHashMap;
@@ -124,6 +127,7 @@ public class KafkaRpcPluginThread extends Thread {
   private final AtomicBoolean thread_running = new AtomicBoolean();
   
   private final AtomicLong messagesReceived = new AtomicLong();
+  private final AtomicLong datapointsReceived = new AtomicLong();
   private final AtomicLong deserializationErrors = new AtomicLong();
   private final AtomicDouble cumulativeRateDelay = new AtomicDouble();
   private final AtomicDouble kafkaWaitTime = new AtomicDouble();
@@ -273,52 +277,69 @@ public class KafkaRpcPluginThread extends Thread {
           case RAW:
           case ROLLUP:
             // Deserialize the event from the received (opaque) message.
+            List<TypedIncomingData> eventList = new ArrayList<TypedIncomingData>();
             TypedIncomingData event;
             try {
-              event = JSON.parseToObject(message.message(), 
-                  TypedIncomingData.class);
+              event = JSON.parseToObject(message.message(), TypedIncomingData.class);
+              eventList.add(event);
             } catch (Throwable ex) {
-              LOG.error("Unable to deserialize data " + ex);
-              deserializationErrors.incrementAndGet();
-              continue;
+              // Possible list of TypedIncomingData objects
+              try {
+                eventList = JSON.parseToObject(message.message(), new TypeReference<List<TypedIncomingData>>() {});
+              } catch (Throwable ex1) {
+                LOG.error("Unable to deserialize data ", ex1);
+                deserializationErrors.incrementAndGet();
+                continue;
+              }
             }
             
             // I &#9825 Google! It's so easy! No release necessary! Thread Safe!
             final double waiting = rate_limiter.acquire();
             cumulativeRateDelay.addAndGet(waiting);
-            event.processData(this, recvTime);
+            datapointsReceived.addAndGet(eventList.size());
+            for (TypedIncomingData ev : eventList) {
+              ev.processData(this, recvTime);
+            }
             break;
           case REQUEUE_RAW:
           case REQUEUE_ROLLUP:
           case UID_ABUSE:
+            List<TypedIncomingData> requeuedList = new ArrayList<TypedIncomingData>();
             TypedIncomingData requeued;
             try {
-              requeued = JSON.parseToObject(message.message(), 
-                  TypedIncomingData.class);
+              requeued = JSON.parseToObject(message.message(), TypedIncomingData.class);
+              requeuedList.add(requeued);
             } catch (Throwable ex) {
-              LOG.error("Unable to deserialize data " + ex);
-              deserializationErrors.incrementAndGet();
-              continue;
+              // Possible list of TypedIncomingData objects
+              try {
+                requeuedList = JSON.parseToObject(message.message(), new TypeReference<List<TypedIncomingData>>() {});
+              } catch (Throwable ex1) {
+                LOG.error("Unable to deserialize data ", ex1);
+                deserializationErrors.incrementAndGet();
+                continue;
+              }
             }
             
             // to avoid tight requeue loops we want to sleep a spell
             // if we receive a data point that was recently added
             // to the queue
-            final long requeueDiff = System.currentTimeMillis() - 
-                requeued.getRequeueTS();
-            if (requeueDiff < requeue_delay) {
-              if (LOG.isDebugEnabled()) {
-                LOG.debug("Sleeping for "  + (requeue_delay - requeueDiff) 
-                    + " ms due to requeue delay");
+            datapointsReceived.addAndGet(requeuedList.size());
+            for(TypedIncomingData ev : requeuedList) {
+              final long requeueDiff = System.currentTimeMillis() - ev.getRequeueTS();
+              if (requeueDiff < requeue_delay) {
+                if (LOG.isDebugEnabled()) {
+                  LOG.debug("Sleeping for "  + (requeue_delay - requeueDiff)
+                          + " ms due to requeue delay");
+                }
+                //incrementCounter(CounterType.RequeuesDelayed, ns);
+                Thread.sleep(requeue_delay - requeueDiff);
               }
-              //incrementCounter(CounterType.RequeuesDelayed, ns);
-              Thread.sleep(requeue_delay - requeueDiff);
+
+              // I &#9825 Google! It's so easy! No release necessary! Thread Safe!
+              final double w = rate_limiter.acquire();
+              cumulativeRateDelay.addAndGet(w);
+              ev.processData(this, recvTime);
             }
-            
-            // I &#9825 Google! It's so easy! No release necessary! Thread Safe!
-            final double w = rate_limiter.acquire();
-            cumulativeRateDelay.addAndGet(w);
-            requeued.processData(this, recvTime);
             break;
           default:
               throw new IllegalStateException("Unknown consumer type: " + 
@@ -437,6 +458,11 @@ public class KafkaRpcPluginThread extends Thread {
   /** @return the number of messages received from Kafka */
   public long getMessagesReceived() {
     return messagesReceived.get();
+  }
+
+  /** @return the number of datapoints received from Kafka messages */
+  public long getDatapointsReceived() {
+    return datapointsReceived.get();
   }
   
   /** @return the number of deserialization errors */

--- a/src/main/java/net/opentsdb/tsd/KafkaRpcPluginThread.java
+++ b/src/main/java/net/opentsdb/tsd/KafkaRpcPluginThread.java
@@ -279,7 +279,6 @@ public class KafkaRpcPluginThread extends Thread {
             List<TypedIncomingData> eventList = new ArrayList<TypedIncomingData>();
             TypedIncomingData event;
             try {
-              String val = new String(message.message());
               event = JSON.parseToObject(message.message(), TypedIncomingData.class);
               eventList.add(event);
             } catch (Throwable ex) {
@@ -287,7 +286,7 @@ public class KafkaRpcPluginThread extends Thread {
               try {
                 eventList = JSON.parseToObject(message.message(), new TypeReference<List<TypedIncomingData>>() {});
               } catch (Throwable ex1) {
-                LOG.error("Unable to deserialize data " + ex);
+                LOG.error("Unable to deserialize data ", ex1);
                 deserializationErrors.incrementAndGet();
                 continue;
               }
@@ -313,7 +312,7 @@ public class KafkaRpcPluginThread extends Thread {
               try {
                 requeuedList = JSON.parseToObject(message.message(), new TypeReference<List<TypedIncomingData>>() {});
               } catch (Throwable ex1) {
-                LOG.error("Unable to deserialize data " + ex);
+                LOG.error("Unable to deserialize data ", ex1);
                 deserializationErrors.incrementAndGet();
                 continue;
               }

--- a/src/test/java/net/opentsdb/tsd/TestKafkaRpcPluginGroup.java
+++ b/src/test/java/net/opentsdb/tsd/TestKafkaRpcPluginGroup.java
@@ -301,6 +301,7 @@ public class TestKafkaRpcPluginGroup {
     assertEquals(0, group.getRestarts());
     assertEquals(0, group.getRebalanceFailures());
     assertEquals(0, group.getMessagesReceived());
+    assertEquals(0, group.getDatapointsReceived());
     assertEquals(0, group.getDeserializationErrors());
   }
 


### PR DESCRIPTION
This PR adds multiple datapoint per message support to opentsdb-rpc-kafka, first trying to deserialize a single datapoint and, failing that, trying to deserialize a list of datapoints. The idea is to have larger sized Kafka messages, but fewer of them, in order to handle higher datapoint volumes. Also, a new counter called `datapointsReceived` has been added for cases where multiple datapoints per message occur.