### PR TITLE
Instantiate plugin threads after deserialiser

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ The following properties can be stored in the ``opentsdb.conf`` file:
 |KafkaRpcPlugin.groups|String|Required|A comma separated list of one or more consumer group names.||TsdbConsumer,TsdbRequeueConsumer|
 |KafkaRpcPlugin.\<GROUPNAME\>.topics|String|Required|A comma separated list of one or more topics for the ``<GROUPNAME>`` to consume from.||TSDB_1,TSDB_2|
 |KafkaRpcPlugin.\<GROUPNAME\>.consumerType|String|Required|The type of messages written to the queue. TODO. For now, leave it as ``raw``||raw|
-|KafkaRpcPlugin.\<GROUPNAME\>.Deserializer|String|Required|The deserialization class to use for parsing messages from the Kafka topic.||net.opentsdb.data.deserializers.JSONDeserializer|
+|KafkaRpcPlugin.\<GROUPNAME\>.deserializer|String|Required|The deserialization class to use for parsing messages from the Kafka topic.||net.opentsdb.data.deserializers.JSONDeserializer|
 |KafkaRpcPlugin.\<GROUPNAME\>.rate|Integer|Required|How many messages per second to throttle the total of consumer threads at for the consumer group||250000|
 |KafkaRpcPlugin.\<GROUPNAME\>.threads|Integer|Required|The number of consumer threads to create per group||4|
 |tsd.http.rpc.plugins|String|Optional|A comma separated list of HTTP RPC plugins to load. Included with this package is a plugin that allows for fetching stats from the Kafka plugin as well as viewing or modifying the write rate during runtime.||net.opentsdb.tsd.KafkaHttpRpcPlugin|

--- a/src/main/java/net/opentsdb/tsd/KafkaRpcPluginGroup.java
+++ b/src/main/java/net/opentsdb/tsd/KafkaRpcPluginGroup.java
@@ -129,12 +129,6 @@ public class KafkaRpcPluginGroup implements TimerTask {
             : KafkaRpcPluginConfig.DEFAULT_CONSUMER_THREADS;
     kafka_consumers = new ArrayList<KafkaRpcPluginThread>(num_threads);
     
-    for (int i = 0; i < num_threads; i++) {
-      kafka_consumers.add(new KafkaRpcPluginThread(this, i, topics));
-    }
-    
-    timer.newTimeout(this, config.threadCheckInterval(), TimeUnit.MILLISECONDS);
-    
     final String deser_class = config.getString(
         KafkaRpcPluginConfig.PLUGIN_PROPERTY_BASE + groupID + ".deserializer");
     if (Strings.isNullOrEmpty(deser_class)) {
@@ -179,6 +173,12 @@ public class KafkaRpcPluginGroup implements TimerTask {
       throw new IllegalArgumentException("Unable to find a deserializer "
           + "for class [" + deser_class + "]");
     }
+
+    for (int i = 0; i < num_threads; i++) {
+      kafka_consumers.add(new KafkaRpcPluginThread(this, i, topics));
+    }
+
+    timer.newTimeout(this, config.threadCheckInterval(), TimeUnit.MILLISECONDS);
   }
   
   @Override


### PR DESCRIPTION
This moves the instantiation of the plugin thread objects after the
creation of the deserialiser. Previously, the threads were trying to
access the deserialiser which wasn't initialised yet and were trying to
work with a null pointer.

Resolves: #10