### PR TITLE
Fix shaded build and Deserializer.initialize not being called

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -205,7 +205,7 @@
 		              <include>org.scala-lang:*</include>
 		              <include>com.yammer.metrics:*</include>
 		              <include>org.xerial.snappy:*</include>
-		              <include>et.sf.jopt-simple:*</include>
+		              <include>net.sf.jopt-simple:*</include>
 		              <include>com.101tec:*</include>
 		              <include>log4j:*</include>
 		            </includes>

--- a/src/main/java/net/opentsdb/tsd/KafkaRpcPluginThread.java
+++ b/src/main/java/net/opentsdb/tsd/KafkaRpcPluginThread.java
@@ -187,6 +187,7 @@ public class KafkaRpcPluginThread extends Thread {
       requeue_delay = 0;
     }
     deserializer = group.getDeserializer();
+    deserializer.initialize(tsdb);
   }
 
   @Override


### PR DESCRIPTION
Two bugfixes for issues we encountered.

First is the shaded jar not including files from `net.sf.jopt-simple`, due to a typo in the pom.
Second is the fact that `Deserializer.initialize`, which we needed, was never called anywhere.